### PR TITLE
Make ETCC data endpoints resilient to upstream outages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="MaidenheadLib" Version="1.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.7" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.7" />

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ sudo docker-compose up -d
 The `radiodata-ui` app is hosted on a Proxmox LXC (`ham-apps`) as a Docker container.
 
 - **Build:** `docker buildx build --platform linux/amd64 -t m0lte/radiodata-ui .`
-- **Run:** `docker run -d --restart unless-stopped -p 8532:8080 m0lte/radiodata-ui`
+- **Run:** `docker run -d --restart unless-stopped -p 8532:8080 \`
+  `-e ETCC_CACHE_PATH=/data/etcc-systems.json -v /opt/radiodata-ui-data:/data m0lte/radiodata-ui`
 - **Data:** UK repeater data via `ukrepeaterlib`; no database.
 - **Public:** `data.m0lte.uk`, via a Cloudflare tunnel → `localhost:8532`.
+
+### Upstream resilience
+
+Repeater data comes from the ETCC API (`api-beta.rsgb.online`). `EtccRepository` caches the
+last-good response so the site keeps working through upstream outages:
+
+- serves the in-memory snapshot while fresh; refreshes are single-flighted;
+- falls back to stale data when the upstream is unreachable, and returns a clean **503**
+  (with `Retry-After`) only when there is no cached data at all — never a 100s hang;
+- a background service refreshes every 10 minutes, so the site recovers automatically when
+  the upstream returns;
+- if `ETCC_CACHE_PATH` points at a writable file (mount a volume, as above), the last-good
+  snapshot is persisted and reloaded on restart. The container runs as UID `1654`, so the
+  host directory must be writable by it (`chown 1654:1654 /opt/radiodata-ui-data`).
+  Persistence is best-effort: if the path is unwritable the app still runs from memory.

--- a/radiodata-ui/EtccRefreshService.cs
+++ b/radiodata-ui/EtccRefreshService.cs
@@ -1,0 +1,41 @@
+using ukrepeaterlib;
+
+namespace radiodata_ui;
+
+/// <summary>
+/// Warms the ETCC cache at startup and refreshes it periodically, so requests are served
+/// from cache (fast) and the site recovers automatically when the upstream API returns —
+/// no user request required to trigger a refresh.
+/// </summary>
+public sealed class EtccRefreshService(EtccRepository repository, ILogger<EtccRefreshService> logger) : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromMinutes(10);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(Interval);
+        try
+        {
+            do
+            {
+                try
+                {
+                    await repository.RefreshAsync(stoppingToken);
+                }
+                catch (EtccDataUnavailableException)
+                {
+                    // Upstream still down and nothing cached yet; already logged. Retry next tick.
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Unexpected error refreshing ETCC cache.");
+                }
+            }
+            while (await timer.WaitForNextTickAsync(stoppingToken));
+        }
+        catch (OperationCanceledException)
+        {
+            // Application is shutting down.
+        }
+    }
+}

--- a/radiodata-ui/Program.cs
+++ b/radiodata-ui/Program.cs
@@ -1,3 +1,4 @@
+using radiodata_ui;
 using ukrepeaterlib;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -8,7 +9,24 @@ builder.Services.AddRazorPages();
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+// Bounded-timeout HTTP client for the ETCC upstream so we fail fast instead of hanging
+// for the HttpClient default of 100 seconds when it is unreachable.
+builder.Services.AddHttpClient("etcc", client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(15);
+});
+
+// Caching repository (singleton) that keeps serving the last-good repeater list through
+// upstream outages. Set ETCC_CACHE_PATH to a writable file to persist it across restarts.
+builder.Services.AddSingleton(sp => new EtccRepository(
+    ct => new EtccApiClient(sp.GetRequiredService<IHttpClientFactory>().CreateClient("etcc")).GetAll(ct),
+    Environment.GetEnvironmentVariable("ETCC_CACHE_PATH"),
+    sp.GetRequiredService<ILogger<EtccRepository>>()));
+
 builder.Services.AddTransient<EtccDataService>();
+builder.Services.AddHostedService<EtccRefreshService>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -21,6 +39,21 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseAuthorization();
+
+// Surface upstream-data outages as a clean 503 (with Retry-After) instead of a 500.
+app.Use(async (context, next) =>
+{
+    try
+    {
+        await next();
+    }
+    catch (EtccDataUnavailableException)
+    {
+        context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+        context.Response.Headers.RetryAfter = "300";
+        await context.Response.WriteAsync("Upstream ETCC repeater data is temporarily unavailable. Please try again shortly.");
+    }
+});
 
 app.MapRazorPages();
 

--- a/ukrepeaterlib-tests/EtccRepositoryTests.cs
+++ b/ukrepeaterlib-tests/EtccRepositoryTests.cs
@@ -1,0 +1,97 @@
+using ukrepeaterlib;
+
+namespace ukrepeaterlib_tests;
+
+public class EtccRepositoryTests
+{
+    private static EtccRecord Rec(string call) => new() { Repeater = call };
+
+    [Fact]
+    public async Task ReturnsFetchedData_WhenUpstreamSucceeds()
+    {
+        var repo = new EtccRepository(_ => Task.FromResult<ICollection<EtccRecord>>([Rec("GB3EZ")]));
+
+        var data = await repo.GetAllAsync();
+
+        Assert.Single(data);
+        Assert.True(repo.HasData);
+    }
+
+    [Fact]
+    public async Task ServesStaleData_WhenUpstreamFailsAfterAPriorSuccess()
+    {
+        var succeed = true;
+        var repo = new EtccRepository(_ => succeed
+            ? Task.FromResult<ICollection<EtccRecord>>([Rec("GB3EZ")])
+            : throw new HttpRequestException("upstream down"));
+
+        // Prime the cache.
+        await repo.GetAllAsync();
+
+        // Upstream now fails; a forced refresh must fall back to the cached snapshot.
+        succeed = false;
+        var data = await repo.RefreshAsync();
+
+        Assert.Single(data);
+        Assert.Equal("GB3EZ", data.First().Repeater);
+    }
+
+    [Fact]
+    public async Task Throws_WhenUpstreamFailsAndNothingCached()
+    {
+        var repo = new EtccRepository(_ => throw new HttpRequestException("upstream down"));
+
+        await Assert.ThrowsAsync<EtccDataUnavailableException>(() => repo.GetAllAsync());
+    }
+
+    [Fact]
+    public async Task Throws_WhenUpstreamTimesOutAndNothingCached()
+    {
+        // The timeout path surfaces as TaskCanceledException, which must also be treated as unavailable.
+        var repo = new EtccRepository(_ => throw new TaskCanceledException("timed out"));
+
+        await Assert.ThrowsAsync<EtccDataUnavailableException>(() => repo.GetAllAsync());
+    }
+
+    [Fact]
+    public async Task ConcurrentCallers_ShareASingleUpstreamFetch()
+    {
+        var calls = 0;
+        var release = new TaskCompletionSource();
+        var repo = new EtccRepository(async _ =>
+        {
+            Interlocked.Increment(ref calls);
+            await release.Task;
+            return (ICollection<EtccRecord>)[Rec("GB3EZ")];
+        });
+
+        var a = repo.GetAllAsync();
+        var b = repo.GetAllAsync();
+        release.SetResult();
+        await Task.WhenAll(a, b);
+
+        Assert.Equal(1, calls); // both callers shared one fetch, not one each
+    }
+
+    [Fact]
+    public async Task PersistsToDisk_AndReloadsOnNextInstance()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"etcc-cache-test-{Guid.NewGuid():N}.json");
+        try
+        {
+            var writer = new EtccRepository(_ => Task.FromResult<ICollection<EtccRecord>>([Rec("GB3EZ")]), path);
+            await writer.GetAllAsync();
+            Assert.True(File.Exists(path));
+
+            // A fresh instance whose upstream is dead should still serve the disk-cached data.
+            var reader = new EtccRepository(_ => throw new HttpRequestException("upstream down"), path);
+            Assert.True(reader.HasData);
+            var data = await reader.GetAllAsync();
+            Assert.Equal("GB3EZ", data.First().Repeater);
+        }
+        finally
+        {
+            if (File.Exists(path)) File.Delete(path);
+        }
+    }
+}

--- a/ukrepeaterlib/EtccApiClient.cs
+++ b/ukrepeaterlib/EtccApiClient.cs
@@ -1,17 +1,20 @@
-﻿using System.Net.Http.Json;
+using System.Net.Http.Json;
 
 namespace ukrepeaterlib;
 
 public class EtccApiClient(HttpClient httpClient)
 {
-    public EtccApiClient() : this(new HttpClient()) { }
+    public const string SystemsUrl = "https://api-beta.rsgb.online/all/systems";
 
-    public async Task<ICollection<EtccRecord>> GetAll()
+    // Fallback for callers that don't get an HttpClient from DI (e.g. tests). A bounded
+    // timeout stops us hanging for the HttpClient default of 100s when the upstream is down.
+    public EtccApiClient() : this(new HttpClient { Timeout = TimeSpan.FromSeconds(15) }) { }
+
+    public async Task<ICollection<EtccRecord>> GetAll(CancellationToken cancellationToken = default)
     {
-        var response = await httpClient.GetAsync("https://api-beta.rsgb.online/all/systems");
+        var response = await httpClient.GetAsync(SystemsUrl, cancellationToken);
         response.EnsureSuccessStatusCode();
-        var repeaters = await response.Content.ReadFromJsonAsync<EtccApiResponse>();
+        var repeaters = await response.Content.ReadFromJsonAsync<EtccApiResponse>(cancellationToken);
         return repeaters?.Data ?? [];
     }
 }
-

--- a/ukrepeaterlib/EtccDataService.cs
+++ b/ukrepeaterlib/EtccDataService.cs
@@ -1,12 +1,18 @@
-﻿namespace ukrepeaterlib;
+namespace ukrepeaterlib;
 
 public class EtccDataService
 {
+    private readonly EtccRepository _repository;
+
+    public EtccDataService(EtccRepository repository) => _repository = repository;
+
+    // Convenience for callers not using DI (e.g. tests): a self-contained repository
+    // backed by a direct API client with no disk cache.
+    public EtccDataService() : this(new EtccRepository(new EtccApiClient())) { }
+
     public async Task<IEnumerable<EtccRecord>> GetVhfAndUhfTargets(string locator, bool includePersonalCalls, int? km)
     {
-        var client = new EtccApiClient();
-
-        var data = await client.GetAll();
+        var data = await _repository.GetAllAsync();
 
         var vhfAndUhfRepeaters = data
             .Where(r => includePersonalCalls == true || r.Repeater.StartsWith("GB") || r.Repeater.StartsWith("MB"))

--- a/ukrepeaterlib/EtccDataUnavailableException.cs
+++ b/ukrepeaterlib/EtccDataUnavailableException.cs
@@ -1,0 +1,9 @@
+namespace ukrepeaterlib;
+
+/// <summary>
+/// Thrown when the upstream ETCC repeater API is unreachable and no cached data is
+/// available to fall back on. Callers should surface this to clients as an HTTP 503
+/// rather than a 500, since it is a transient upstream condition.
+/// </summary>
+public sealed class EtccDataUnavailableException(string message, Exception? innerException = null)
+    : Exception(message, innerException);

--- a/ukrepeaterlib/EtccRepository.cs
+++ b/ukrepeaterlib/EtccRepository.cs
@@ -1,0 +1,166 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace ukrepeaterlib;
+
+/// <summary>
+/// Fetches the ETCC systems list and caches the last-good result so the site keeps
+/// working through upstream outages. Behaviour:
+/// <list type="bullet">
+/// <item>serves the in-memory snapshot while it is fresh (no network hit);</item>
+/// <item>single-flights refreshes — concurrent callers share one upstream fetch;</item>
+/// <item>falls back to the last-good (stale) snapshot when the upstream is unreachable;</item>
+/// <item>throws <see cref="EtccDataUnavailableException"/> only when there is no data at all;</item>
+/// <item>backs off briefly after a failure so an outage doesn't make every request wait;</item>
+/// <item>best-effort persists the last-good snapshot to disk so it survives a restart.</item>
+/// </list>
+/// Registered as a singleton so the cache is shared across requests.
+/// </summary>
+public sealed class EtccRepository
+{
+    private static readonly TimeSpan FreshFor = TimeSpan.FromMinutes(15);
+    private static readonly TimeSpan FailureBackoff = TimeSpan.FromSeconds(30);
+
+    private readonly Func<CancellationToken, Task<ICollection<EtccRecord>>> _fetch;
+    private readonly string? _cachePath;
+    private readonly ILogger? _logger;
+    private readonly object _lock = new();
+    private volatile Snapshot? _snapshot;
+    private Task<ICollection<EtccRecord>>? _inFlight;   // guarded by _lock
+    private DateTimeOffset _lastFailureUtc = DateTimeOffset.MinValue;   // guarded by _lock
+
+    private sealed record Snapshot(DateTimeOffset FetchedAt, ICollection<EtccRecord> Data);
+
+    private sealed record PersistedCache(DateTimeOffset FetchedAt, EtccRecord[] Data);
+
+    /// <param name="fetch">Delegate that fetches the systems list from the upstream API.</param>
+    /// <param name="cachePath">Optional path to persist the last-good snapshot to; null/empty disables disk persistence.</param>
+    public EtccRepository(
+        Func<CancellationToken, Task<ICollection<EtccRecord>>> fetch,
+        string? cachePath = null,
+        ILogger<EtccRepository>? logger = null)
+    {
+        _fetch = fetch;
+        _cachePath = string.IsNullOrWhiteSpace(cachePath) ? null : cachePath;
+        _logger = logger;
+        TryLoadFromDisk();
+    }
+
+    /// <summary>Convenience for callers not using DI (e.g. tests): a direct API client, no disk cache.</summary>
+    public EtccRepository(EtccApiClient client, string? cachePath = null, ILogger<EtccRepository>? logger = null)
+        : this(client.GetAll, cachePath, logger) { }
+
+    public bool HasData => _snapshot is not null;
+
+    public DateTimeOffset? LastUpdatedUtc => _snapshot?.FetchedAt;
+
+    /// <summary>Returns cached data if fresh, otherwise refreshes (falling back to stale on failure).</summary>
+    public Task<ICollection<EtccRecord>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var snapshot = _snapshot;
+        if (snapshot is not null && DateTimeOffset.UtcNow - snapshot.FetchedAt < FreshFor)
+            return Task.FromResult(snapshot.Data);
+
+        return RefreshAsync(cancellationToken);
+    }
+
+    /// <summary>Refreshes from the upstream, serving stale data if the fetch fails and any exists.</summary>
+    public Task<ICollection<EtccRecord>> RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        Task<ICollection<EtccRecord>> inFlight;
+        lock (_lock)
+        {
+            var snapshot = _snapshot;
+            if (snapshot is not null && DateTimeOffset.UtcNow - snapshot.FetchedAt < FreshFor)
+                return Task.FromResult(snapshot.Data);
+
+            // Recently failed and nobody is already fetching: don't make this caller wait on the
+            // upstream again. Serve stale if we have it, otherwise fail fast.
+            if (_inFlight is null && DateTimeOffset.UtcNow - _lastFailureUtc < FailureBackoff)
+            {
+                if (snapshot is not null) return Task.FromResult(snapshot.Data);
+                return Task.FromException<ICollection<EtccRecord>>(new EtccDataUnavailableException(
+                    "The ETCC repeater API is currently unavailable and no cached data is available."));
+            }
+
+            // Join the in-flight fetch if there is one, otherwise start it.
+            _inFlight ??= FetchAndCacheAsync();
+            inFlight = _inFlight;
+        }
+
+        // Let a caller's cancellation abandon its own wait without cancelling the shared fetch.
+        return cancellationToken.CanBeCanceled ? inFlight.WaitAsync(cancellationToken) : inFlight;
+    }
+
+    private async Task<ICollection<EtccRecord>> FetchAndCacheAsync()
+    {
+        // Never complete synchronously while a caller holds _lock (the finally re-enters it).
+        await Task.Yield();
+        try
+        {
+            var data = await _fetch(CancellationToken.None);
+            var snapshot = new Snapshot(DateTimeOffset.UtcNow, data);
+            _snapshot = snapshot;
+            TrySaveToDisk(snapshot);
+            _logger?.LogInformation("Fetched {Count} ETCC systems from upstream.", data.Count);
+            return data;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or OperationCanceledException)
+        {
+            lock (_lock) { _lastFailureUtc = DateTimeOffset.UtcNow; }
+
+            var stale = _snapshot;
+            if (stale is not null)
+            {
+                _logger?.LogWarning(ex, "ETCC upstream unavailable; serving cached data from {FetchedAt:o}.", stale.FetchedAt);
+                return stale.Data;
+            }
+
+            _logger?.LogError(ex, "ETCC upstream unavailable and no cached data to fall back on.");
+            throw new EtccDataUnavailableException(
+                "The ETCC repeater API is currently unavailable and no cached data is available.", ex);
+        }
+        finally
+        {
+            lock (_lock) { _inFlight = null; }
+        }
+    }
+
+    private void TryLoadFromDisk()
+    {
+        if (_cachePath is null || !File.Exists(_cachePath)) return;
+        try
+        {
+            var cache = JsonSerializer.Deserialize<PersistedCache>(File.ReadAllText(_cachePath));
+            if (cache is { Data.Length: > 0 })
+            {
+                _snapshot = new Snapshot(cache.FetchedAt, cache.Data);
+                _logger?.LogInformation("Loaded {Count} ETCC systems from disk cache dated {FetchedAt:o}.", cache.Data.Length, cache.FetchedAt);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to load ETCC disk cache from {Path}.", _cachePath);
+        }
+    }
+
+    private void TrySaveToDisk(Snapshot snapshot)
+    {
+        if (_cachePath is null) return;
+        try
+        {
+            var dir = Path.GetDirectoryName(_cachePath);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+            var json = JsonSerializer.Serialize(new PersistedCache(snapshot.FetchedAt, snapshot.Data.ToArray()));
+            // Write-then-rename so a crash mid-write can't leave a truncated cache file.
+            var tmp = _cachePath + ".tmp";
+            File.WriteAllText(tmp, json);
+            File.Move(tmp, _cachePath, overwrite: true);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to persist ETCC disk cache to {Path}.", _cachePath);
+        }
+    }
+}

--- a/ukrepeaterlib/ukrepeaterlib.csproj
+++ b/ukrepeaterlib/ukrepeaterlib.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="MaidenheadLib" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem

`data.m0lte.uk/api/chirpcsv/{locator}` (and the other ETCC-backed endpoints:
`icomcsv`, `json`, and the base `/api` route) were returning a 500 error page.

Root cause: each request fetches the full systems list from
`https://api-beta.rsgb.online/all/systems` with **no caching** and the **default
100s `HttpClient` timeout**. That upstream has been unreachable (TCP connect
timing out) since ~2 Jul 2026, so every request hung for 100s then threw
`TaskCanceledException` → 500. The homepage was unaffected; only the data
endpoints were down.

## Fix (resilience only — same RSGB data source)

- **`EtccRepository`** — singleton that caches the last-good systems list, serves
  it while fresh (15 min), single-flights refreshes so concurrent callers share
  one upstream fetch, and **falls back to stale data** when the upstream is down.
- **Bounded 15s timeout** on the ETCC `HttpClient` instead of 100s, plus a short
  post-failure backoff so repeat requests during an outage return immediately
  instead of each waiting on the upstream.
- **`EtccRefreshService`** — background refresh every 10 min that warms the cache
  and lets the site **recover automatically** when the upstream returns.
- **Clean 503** (with `Retry-After`) when there's genuinely no data, instead of a
  100s hang → 500.
- **Optional disk persistence** via `ETCC_CACHE_PATH` so the last-good snapshot
  survives a container restart (best-effort; falls back to memory-only).
- Unit tests for the cache / stale-serving / single-flight / disk-persist behaviour.

## Deploy

Already built and deployed to the `ham-apps` LXC as `radiodata-ui:amd64-resilient`
(old container kept stopped as `radiodata-ui-old` for rollback). The run command
now mounts a cache volume — see the updated README. `data.m0lte.uk` currently
returns a fast **503** (not a 100s 500) and will self-heal once the RSGB API is
back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY71v3fTfypfup17qMBEcU